### PR TITLE
add namesrvAddr support for rocket mq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ build/Release
 node_modules
 
 example/.config.js
+
+.idea/

--- a/lib/remoting_client.js
+++ b/lib/remoting_client.js
@@ -109,22 +109,29 @@ class RemotingClient extends Base {
     yield this.updateNameServerAddressList();
   }
 
+  * getNameServerAddressList() {
+    if (this.options.namesrvAddr) {
+      return this.options.namesrvAddr;
+    }
+    const ret = yield this.urllib.request(this.options.onsAddr);
+
+    if (ret.status === 200) {
+      return ret.data.toString().trim();
+    }
+    throw new Error('[mq:remoting_client] fetch name server addresses failed, ret.statusCode: ' + ret.status);
+  }
+
   /**
    * fetch name server address list
    * @return {void}
    */
   * updateNameServerAddressList() {
-    const ret = yield this.urllib.request(this.options.onsAddr);
-    if (ret.status === 200) {
-      const addrs = ret.data.toString().trim();
-      const newList = addrs.split(';');
-      if (newList.length) {
-        this._namesrvAddrList = newList;
-      }
-      this.logger.info('[mq:remoting_client] fetch name server addresses successfully, address: %s', addrs);
-    } else {
-      throw new Error('[mq:remoting_client] fetch name server addresses failed, ret.statusCode: ' + ret.status);
+    const addrs = yield this.getNameServerAddressList();
+    const newList = addrs.split(';');
+    if (newList.length) {
+      this._namesrvAddrList = newList;
     }
+    this.logger.info('[mq:remoting_client] fetch name server addresses successfully, address: %s', addrs);
   }
 
   /**


### PR DESCRIPTION
看了下目前没有支持rocket mq的SDK 因此发了一个PR 允许配置项传入`namesrvAddr`, 主要是方便开发环境测试