### PR TITLE
Fix consumer & producer initialize issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,12 @@ producer
 ```js
 'use strict';
 
+const httpclient = require('urllib');
 const Producer = require('ali-ons').Producer;
 const Message = require('ali-ons').Message;
 
 const producer = new Producer({
+  httpclient,
   accessKey: 'your-accesskey',
   secretKey: 'your-secretkey',
   producerGroup: 'your-producer-group',

--- a/example/consumer.js
+++ b/example/consumer.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const urllib = require('urllib');
+const httpclient = require('urllib');
 const logger = require('./logger');
 const Consumer = require('../').Consumer;
 const config = require('./config');
 const consumer = new Consumer(Object.assign(config, {
-  urllib,
+  httpclient,
   logger,
   // isBroadcast: true,
   consumeFromWhere: 'CONSUME_FROM_LAST_OFFSET_AND_FROM_MIN_WHEN_BOOT_FIRST',

--- a/example/producer.js
+++ b/example/producer.js
@@ -3,11 +3,11 @@
 const co = require('co');
 const logger = require('./logger');
 const config = require('./config');
-const urllib = require('urllib');
+const httpclient = require('urllib');
 const Producer = require('../').Producer;
 const Message = require('../').Message;
 
-const producer = new Producer(Object.assign({ urllib, logger }, config));
+const producer = new Producer(Object.assign({ httpclient, logger }, config));
 co(function*() {
   yield producer.ready();
   const msg = new Message(config.topic, // topic


### PR DESCRIPTION
1) The README.md about how to initialize a producer is lack of essential parameter, httpclient.
2) Those example codes for consumer and producer are using wrong parameter to initialize the instance.