### PR TITLE
feat: support customize queue allocation in broadcast mode

### DIFF
--- a/example/allocate_message_queue_statically.js
+++ b/example/allocate_message_queue_statically.js
@@ -1,0 +1,30 @@
+'use strict';
+
+class AllocateMessageQueueStatically {
+  get name() {
+    return 'STATIC';
+  }
+
+  allocate(consumerGroup, currentCID, mqAll, cidAll) {
+    if (!currentCID || currentCID.length < 1) {
+      throw new Error('currentCID is empty');
+    }
+    if (!mqAll || !mqAll.length) {
+      throw new Error('mqAll is null or mqAll empty');
+    }
+    if (!cidAll || !cidAll.length) {
+      throw new Error('cidAll is null or cidAll empty');
+    }
+
+    const result = [];
+    const index = cidAll.indexOf(currentCID);
+    if (index === -1) { // 不存在此ConsumerId ,直接返回
+      return result;
+    }
+
+    result.push(mqAll[0]);
+    return result;
+  }
+}
+
+module.exports = AllocateMessageQueueStatically;

--- a/example/consumer.js
+++ b/example/consumer.js
@@ -4,11 +4,16 @@ const httpclient = require('urllib');
 const logger = require('./logger');
 const Consumer = require('../').Consumer;
 const config = require('./config');
+
+const AllocateMessageQueueStatically = require('./allocate_message_queue_statically');
+
 const consumer = new Consumer(Object.assign(config, {
   httpclient,
   logger,
-  // isBroadcast: true,
-  consumeFromWhere: 'CONSUME_FROM_LAST_OFFSET_AND_FROM_MIN_WHEN_BOOT_FIRST',
+  allocateMessageQueueStrategy: new AllocateMessageQueueStatically,
+  isBroadcast: true,
+  allocateQueueManually: true,
+  // consumeFromWhere: 'CONSUME_FROM_LAST_OFFSET_AND_FROM_MIN_WHEN_BOOT_FIRST',
 }));
 
 consumer.subscribe(config.topic, '*', async function(msg) {

--- a/example/producer.js
+++ b/example/producer.js
@@ -6,18 +6,26 @@ const httpclient = require('urllib');
 const Producer = require('../').Producer;
 const Message = require('../').Message;
 
-const producer = new Producer(Object.assign({ httpclient, logger }, config));
-(async () => {
-  try {
-    await producer.ready();
-    const msg = new Message(config.topic, // topic
-      'TagA', // tag
-      'Hello ONS !!! ' // body
-    );
+const TopicPublishStatically = require('./topic_publish_statically');
 
-    const sendResult = await producer.send(msg);
-    console.log(sendResult);
-  } catch (err) {
-    console.error(err)
+const producer = new Producer(Object.assign({
+  httpclient,
+  logger,
+  topicPublishInfo: TopicPublishStatically,
+}, config));
+(async () => {
+  await producer.ready();
+  for (let i = 0; i < 100; i++) {
+    try {
+      const msg = new Message(config.topic, // topic
+        'TagA', // tag
+        'Hello ONS !!! ' // body
+      );
+
+      const sendResult = await producer.send(msg);
+      console.log(sendResult.msgId, sendResult.messageQueue.key);
+    } catch (err) {
+      console.error(err)
+    }
   }
 })();

--- a/example/topic_publish_statically.js
+++ b/example/topic_publish_statically.js
@@ -1,0 +1,27 @@
+'use strict';
+
+class TopicPublishStatically {
+  constructor() {
+    this.orderTopic = false;
+    this.haveTopicRouterInfo = false;
+    this.messageQueueList = [];
+    this.sendWhichQueue = 0;
+  }
+
+  /**
+   * 是否可用
+   */
+  get ok() {
+    return this.messageQueueList && this.messageQueueList.length;
+  }
+
+  /**
+   * 如果lastBrokerName不为null，则寻找与其不同的MessageQueue
+   * @return {Object} queue
+   */
+  selectOneMessageQueue() {
+    return this.messageQueueList[this.sendWhichQueue];
+  }
+}
+
+module.exports = TopicPublishStatically;

--- a/lib/client_config.js
+++ b/lib/client_config.js
@@ -2,6 +2,7 @@
 
 const Base = require('sdk-base');
 const address = require('address');
+const TopicPublishInfo = require('./producer/topic_publish_info');
 
 const defaultOptions = {
   instanceName: 'DEFAULT',
@@ -18,6 +19,8 @@ const defaultOptions = {
   // 杭州深圳云环境：http://mq4finance-sz.addr.aliyun.com:8080/rocketmq/nsaddr4client-internal
   onsAddr: 'http://onsaddr-internet.aliyun.com/rocketmq/nsaddr4client-internet',
   onsChannel: 'ALIYUN', // CLOUD, ALIYUN, ALL
+
+  topicPublishInfo: TopicPublishInfo,
 };
 
 class ClientConfig extends Base {

--- a/lib/consumer/mq_push_consumer.js
+++ b/lib/consumer/mq_push_consumer.js
@@ -468,7 +468,7 @@ class MQPushConsumer extends ClientConfig {
 
     let changed;
     let allocateResult = mqSet;
-    if (this.options.isBroadcast) {
+    if (this.options.isBroadcast && !this.options.allocateQueueManually) {
       changed = await this.updateProcessQueueTableInRebalance(topic, mqSet);
     } else {
       const cidAll = await this._mqClient.findConsumerIdList(topic, this.consumerGroup);

--- a/lib/mq_client.js
+++ b/lib/mq_client.js
@@ -8,7 +8,6 @@ const MixAll = require('./mix_all');
 const MQClientAPI = require('./mq_client_api');
 const MessageQueue = require('./message_queue');
 const PermName = require('./protocol/perm_name');
-const TopicPublishInfo = require('./producer/topic_publish_info');
 
 const instanceTable = new Map();
 
@@ -342,7 +341,7 @@ class MQClient extends MQClientAPI {
   }
 
   _topicRouteData2TopicPublishInfo(topic, topicRouteData) {
-    const info = new TopicPublishInfo();
+    const info = new this.options.topicPublishInfo();
     // 顺序消息
     if (topicRouteData.orderTopicConf && topicRouteData.orderTopicConf.length) {
       const brokers = topicRouteData.orderTopicConf.split(';');

--- a/lib/mq_client_api.js
+++ b/lib/mq_client_api.js
@@ -398,7 +398,6 @@ class MQClientAPI extends RemotingClient {
         msg.properties[MessageConst.PROPERTY_MAX_OFFSET] = responseHeader.maxOffset.toString();
       }
     }
-
     return {
       pullStatus,
       nextBeginOffset: Number(responseHeader.nextBeginOffset),

--- a/lib/producer/mq_producer.js
+++ b/lib/producer/mq_producer.js
@@ -9,7 +9,6 @@ const SendStatus = require('./send_status');
 const ClientConfig = require('../client_config');
 // const PermName = require('../protocol/perm_name');
 const MessageConst = require('../message/message_const');
-const TopicPublishInfo = require('./topic_publish_info');
 const ResponseCode = require('../protocol/response_code');
 const MessageSysFlag = require('../utils/message_sys_flag');
 const MessageDecoder = require('../message/message_decoder');
@@ -35,7 +34,7 @@ class MQProducer extends ClientConfig {
    * @constructor
    */
   constructor(options) {
-    super(Object.assign({ initMethod: 'init' }, defaultOptions, options));
+    super(Object.assign({}, defaultOptions, options, { initMethod: 'init' }));
 
     this._topicPublishInfoTable = new Map();
     this._inited = false;
@@ -77,7 +76,7 @@ class MQProducer extends ClientConfig {
    * @return {void}
    */
   async init() {
-    // this._topicPublishInfoTable.set(this.createTopicKey, new TopicPublishInfo());
+    // this._topicPublishInfoTable.set(this.createTopicKey, new this.options.topicPublishInfo());
     this._mqClient.registerProducer(this.producerGroup, this);
     await this._mqClient.ready();
     this.logger.info('[mq:producer] producer started');
@@ -239,7 +238,7 @@ class MQProducer extends ClientConfig {
   async tryToFindTopicPublishInfo(topic) {
     let topicPublishInfo = this._topicPublishInfoTable.get(topic);
     if (!topicPublishInfo || !topicPublishInfo.ok) {
-      this._topicPublishInfoTable.set(topic, new TopicPublishInfo());
+      this._topicPublishInfoTable.set(topic, new this.options.topicPublishInfo());
       await this._mqClient.updateTopicRouteInfoFromNameServer(topic);
       topicPublishInfo = this._topicPublishInfoTable.get(topic);
     }

--- a/test/customize.test.js
+++ b/test/customize.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const mm = require('mm');
+const path = require('path');
+const osenv = require('osenv');
+const assert = require('assert');
+const httpclient = require('urllib');
+const Message = require('../').Message;
+const Consumer = require('../').Consumer;
+const Producer = require('../').Producer;
+const sleep = require('mz-modules/sleep');
+const rimraf = require('mz-modules/rimraf');
+const config = require('../example/config');
+const TopicPublishStatically = require('../example/topic_publish_statically');
+const AllocateMessageQueueStatically = require('../example/allocate_message_queue_statically');
+
+const TOPIC = config.topic;
+const localOffsetStoreDir = path.join(osenv.home(), '.rocketmq_offsets_node');
+
+describe('test/customize.test.js', () => {
+  let consumer;
+  let producer;
+
+  before(() => {
+    return rimraf(localOffsetStoreDir);
+  });
+  before(async () => {
+    consumer = new Consumer(Object.assign({
+      httpclient,
+      persistent: true,
+      rebalanceInterval: 2000,
+      isBroadcast: true,
+      allocateQueueManually: true,
+      allocateMessageQueueStrategy: new AllocateMessageQueueStatically(),
+      topicPublishInfo: TopicPublishStatically,
+    }, config));
+    producer = new Producer(Object.assign({
+      httpclient,
+      topicPublishInfo: TopicPublishStatically,
+    }, config));
+
+    await consumer.ready();
+    await producer.ready();
+  });
+
+  after(async () => {
+    await producer.close();
+    const originFn = consumer._offsetStore.persistAll;
+    mm(consumer._offsetStore, 'persistAll', async mqs => {
+      assert(mqs && mqs.length);
+      return await originFn.call(consumer._offsetStore, mqs);
+    });
+    await consumer.close();
+  });
+
+  afterEach(mm.restore);
+
+  it('should subscribe message ok', async () => {
+    const sent = new Set();
+    const received = new Set();
+    consumer.subscribe(TOPIC, 'TagA', async msg => {
+      console.log('message receive ------------> ', msg.msgId, msg.body.toString());
+      assert(msg.tags !== 'TagB');
+      received.add(msg.msgId);
+    });
+
+    await sleep(5000);
+
+    for (let i = 0; i < 10; i++) {
+      const msg = new Message(TOPIC, // topic
+        'TagA', // tag
+        'Hello MetaQ !!! ' // body
+      );
+      const sendResult = await producer.send(msg);
+      assert(sendResult && sendResult.msgId);
+      console.log('send message success,', sendResult.msgId, sendResult.messageQueue.key, sendResult.queueOffset);
+      sent.add(sendResult.msgId);
+    }
+
+    await sleep(5000);
+
+    for (const msgId of sent.values()) {
+      assert(received.has(msgId));
+    }
+  });
+});


### PR DESCRIPTION
支持在广播模式下的自定义队列分配

在 [egg-ons 的配置](https://github.com/eggjs/egg-ons/blob/master/config/config.default.js#L17)里面需要配三个东西

- topicPublishInfo: 一个类，用于 producer 发送消息时决定发往哪个队列
- allocateMessageQueueStrategy：一个 new 出来的实例，用于 consumer 拉取消息时决定从哪些队列里拉取
- allocateQueueManually => true

