### PR TITLE
fix: namespace instance subscribe failed

### DIFF
--- a/lib/client_config.js
+++ b/lib/client_config.js
@@ -11,7 +11,7 @@ const defaultOptions = {
   rebalanceInterval: 10 * 1000,
   clientIP: address.ip(),
   unitMode: false,
-  // 阿里云自创建实例，需要 ns 前缀
+  // 阿里云自创建实例, 阿里云ons-rocketmq控制台实例ID, MQ_INST开头
   namespace: '',
   // 公有云生产环境：http://onsaddr-internal.aliyun.com:8080/rocketmq/nsaddr4client-internal
   // 公有云公测环境：http://onsaddr-internet.aliyun.com/rocketmq/nsaddr4client-internet

--- a/lib/consumer/mq_push_consumer.js
+++ b/lib/consumer/mq_push_consumer.js
@@ -184,7 +184,7 @@ class MQPushConsumer extends ClientConfig {
    */
   subscribe(topic, subExpression, handler) {
     // 添加 namespace 前缀
-    if (this.namespace && !topic.startsWith(this.namespace)) {
+    if (this.namespace && !topic.includes(this.namespace)) {
       topic = `${this.namespace}%${topic}`;
     }
 


### PR DESCRIPTION
修复阿里云自定义实例下mq订阅失败的问题

subscribe的方法不仅针对用户的订阅，还包括%RETRY%开头的topic订阅

RETRY的自定义实例下的订阅topic应该是 %RETRY%namespace%topic