### PR TITLE
Add user-properties functionality

### DIFF
--- a/lib/message/message.js
+++ b/lib/message/message.js
@@ -34,6 +34,8 @@ class Message {
     this.properties = {};
     this.msgId = null;
 
+    this._userProperties = {};
+
     this.tags = tags;
 
     if (body && is.string(body)) {
@@ -154,8 +156,13 @@ class Message {
    */
   setUserProperties(props) {
     for (const [ k, v ] of Object.entries(props)) {
-      Object.assign(this.properties, { [k]: v });
+      Object.assign(this._userProperties, { [k]: v });
     }
+    Object.assign(this.properties, this._userProperties);
+  }
+
+  getUserProperties() {
+    return this._userProperties;
   }
 
 }

--- a/lib/message/message.js
+++ b/lib/message/message.js
@@ -148,6 +148,16 @@ class Message {
     return this.properties[MessageConst.SYSTEM_PROP_KEY_STARTDELIVERTIME] || 0;
   }
 
+  /**
+   *
+   * @param {Object} props the user properties
+   */
+  setUserProperties(props) {
+    for (const [ k, v ] of Object.entries(props)) {
+      Object.assign(this.properties, { [k]: v });
+    }
+  }
+
 }
 
 module.exports = Message;

--- a/lib/producer/mq_producer.js
+++ b/lib/producer/mq_producer.js
@@ -125,7 +125,7 @@ class MQProducer extends ClientConfig {
       this._topicPublishInfoTable.set(topic, info);
       if (prev) {
         info.sendWhichQueue = prev.sendWhichQueue;
-        this.logger.warn('[mq:producer] updateTopicPublishInfo() prev is not null, %j', prev);
+        this.logger.warn('[mq:producer] updateTopicPublishInfo() prev is not null, \n%s', JSON.stringify(prev, null, 2));
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "homepage": "https://github.com/ali-sdk/ali-ons#readme",
   "dependencies": {
-    "JSON2": "^0.1.0",
     "address": "^1.1.2",
     "binary-search-insert": "^1.0.3",
     "byte": "^2.0.0",
@@ -40,6 +39,7 @@
     "co-gather": "^1.0.1",
     "debug": "^4.3.1",
     "is-type-of": "^1.2.1",
+    "JSON2": "^0.1.0",
     "long": "^4.0.0",
     "mkdirp": "^1.0.4",
     "mz-modules": "^2.1.0",

--- a/test/user_properties.test.js
+++ b/test/user_properties.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const mm = require('mm');
+const assert = require('assert');
+const httpclient = require('urllib');
+const config = require('../example/config');
+const Consumer = require('../').Consumer;
+const Producer = require('../').Producer;
+const sleep = require('mz-modules/sleep');
+const Message = require('../').Message;
+
+
+const TOPIC = config.topic;
+
+describe('test/user_properties.test.js', () => {
+  let producer,
+    consumer;
+
+  before(async () => {
+    producer = new Producer(Object.assign({
+      httpclient,
+    }, config));
+    await producer.ready();
+    consumer = new Consumer(Object.assign({
+      httpclient,
+    }, config));
+    await consumer.ready();
+  });
+
+  after(async () => {
+    await producer.close();
+    await consumer.close();
+  });
+
+  afterEach(mm.restore);
+
+
+  const tests = [
+    { tags: null, body: 'Test body', userProperties: { prop1: 'val1', prop2: 'val2' } },
+  ];
+
+  tests.forEach(test => {
+    it('should send and receive messages with user-defined properties', async () => {
+      await sleep(3000);
+
+      const tagsString = test.tags ? test.tags.join('||') : '*';
+      const msg = new Message(
+        TOPIC,
+        tagsString,
+        test.body
+      );
+
+      test.userProperties && msg.setUserProperties(test.userProperties);
+
+      const sendResult = await producer.send(msg);
+      assert(sendResult && sendResult.msgId);
+
+      const msgId = sendResult.msgId;
+      console.log(`Send Result: ${JSON.stringify(sendResult, null, 2)}`);
+
+      await new Promise(r => {
+        consumer.subscribe(TOPIC, tagsString, async msg => {
+          if (msg.msgId === msgId) {
+            test.userProperties && Object.entries(test.userProperties)
+              .forEach(([ k, v ]) => {
+                assert(msg.properties[k] === v);
+              });
+            test.body && assert(msg.body.toString() === test.body);
+            r();
+          }
+        });
+      });
+    }).timeout(20000);
+
+  });
+});


### PR DESCRIPTION
This addition allows the package to support user properties as seen in the [Message](https://javadoc.io/doc/com.aliyun.openservices/ons-api/latest/com/aliyun/openservices/ons/api/Message.html) class from the [com.aliyun.openservices](https://javadoc.io/doc/com.aliyun.openservices) [ons.api](https://javadoc.io/doc/com.aliyun.openservices/ons-api/latest/index.html) Java library. We have a client who uses this library to interact with rocketmq and wants to pass certain meta-data using user-defined properties.